### PR TITLE
fix(action.yml): include all a11y issues in vpat

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,8 @@ inputs:
     description: File to output the report to. Accepts "{DATE}" and "{PRODUCT}" placeholders.
     default: vpat-{DATE}-{PRODUCT}.md
   vpat-label:
-    description: Label to filter VPAT issues by
-    default: VPAT
+    description: Issues with this label will be included in the VPAT
+    default: A11Y
   additional-labels:
     description: Additional labels to filter issues by
     default: ""


### PR DESCRIPTION
Prompted by this Slack discussion:
https://deque.slack.com/archives/C056RAZLM71/p1684348078943359

With a default value of `VPAT` for the `vpat-label` input, only issues with the `VPAT` label will be included in the VPAT generated by this action. The problem is that the `VPAT` label is only applied to issues when the person creating the issue checks the “Discovered during VPAT” checkbox in the issue description (see [these lines](https://github.com/dequelabs/action-a11y-issue-labeler/blob/main/src/main.ts#L108-L112)). This means that issues created in response to user feedback, or issues discovered by developers, won't be included in the VPAT report because the “Discovered during VPAT” won't be checked when such issues are created.

This changes the default value of the `vpat-label` input to `A11Y`, which is a label applied to all issues created using the [Accessibility Violation](https://github.com/dequelabs/a11y-metrics-poc/blob/main/.github/ISSUE_TEMPLATE/accessibility_violation.md) issue template. This will ensure that all open issues created using this template will be included in the VPAT report.

By extension, this change also "un-overloads" the `VPAT` label so it can be used for its intended purpose to filter issues that were actually “Discovered during VPAT”.

In order for this change to impact projects that are already set up with this action, those projects will have to remove the following line from their .github/workflows/vpat.yml file:

```yml
- uses: dequelabs/action-vpat-report@main
  with:
    product-name: Your product name
    output-file: vpats/{DATE}-{PRODUCT}.md
    vpat-label: VPAT <---------------------------------- Remove this line
```