### PR TITLE
fix: upgrade to node20 and checkout and setup-node actions to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: yarn
@@ -16,11 +16,11 @@ jobs:
   generate_report:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./
         with:
           product-name: Test
-      - uses: peter-evans/create-pull-request@v4
+      - uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "docs: Generate a VPAT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn lint

--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ inputs:
     description: Additional labels to filter issues by
     default: ""
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
Closes https://github.com/dequelabs/action-vpat-report/issues/7

https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

> For Actions maintainers: Update your actions to run on Node20 instead of Node16