### PR TITLE
fix: only include issues with vpat label

### DIFF
--- a/src/buildTable.ts
+++ b/src/buildTable.ts
@@ -25,7 +25,7 @@ const buildTable = ({ level, issues, owner, repo }: Params) => {
     const relevantIssues = issues
       .filter((issue) => {
         const labels = issue.labels.map((l) => l.name);
-        return labels.includes("WCAG " + sc.id);
+        return labels.includes("VPAT") && labels.includes("WCAG " + sc.id);
       })
       .sort((a, b) => {
         const aDate = new Date(a.created_at);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2016",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./src",


### PR DESCRIPTION
Fixes the issue where issues labeled "best practice" but not "VPAT" are being included in the VPAT report.