### PR TITLE
ci: gate the sample-VPAT publish step to main pushes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,15 @@ jobs:
           product-name: Test
       - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Dependabot-triggered runs get a read-only GITHUB_TOKEN, so pushing
+          # the test-vpat-report branch 403s ("Permission to ... denied to
+          # github-actions[bot]") and every Dependabot PR fails this job.
+          # VPAT_BOT_PAT must live in the *Dependabot* secret store — Actions
+          # secrets are not exposed to Dependabot-triggered runs, and the two
+          # stores are separate. It resolves to "" on human/main pushes unless
+          # it is also added as an Actions secret, hence the GITHUB_TOKEN
+          # fallback: those runs already work and must keep working.
+          token: ${{ secrets.VPAT_BOT_PAT || secrets.GITHUB_TOKEN }}
           commit-message: "docs: Generate a VPAT"
           branch: test-vpat-report
           base: main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,17 +20,18 @@ jobs:
       - uses: ./
         with:
           product-name: Test
-      - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
+      # Publishing the sample VPAT needs a writable token, so it only runs when
+      # main moves. Dependabot-triggered runs get a read-only GITHUB_TOKEN and
+      # this push 403s ("Permission to ... denied to github-actions[bot]"),
+      # which failed the job on every Dependabot PR. A `permissions:` block
+      # cannot fix that — the token is capped read-only for those runs.
+      # The `uses: ./` step above still exercises the action on every branch,
+      # so a bump that breaks report generation is still caught here.
+      # The actor clause covers a Dependabot-authored push landing on main.
+      - if: github.ref == 'refs/heads/main' && github.actor != 'dependabot[bot]'
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         with:
-          # Dependabot-triggered runs get a read-only GITHUB_TOKEN, so pushing
-          # the test-vpat-report branch 403s ("Permission to ... denied to
-          # github-actions[bot]") and every Dependabot PR fails this job.
-          # VPAT_BOT_PAT must live in the *Dependabot* secret store — Actions
-          # secrets are not exposed to Dependabot-triggered runs, and the two
-          # stores are separate. It resolves to "" on human/main pushes unless
-          # it is also added as an Actions secret, hence the GITHUB_TOKEN
-          # fallback: those runs already work and must keep working.
-          token: ${{ secrets.VPAT_BOT_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "docs: Generate a VPAT"
           branch: test-vpat-report
           base: main


### PR DESCRIPTION
## What

The `create-pull-request` step in `generate_report` now runs only when `main` moves:

```yaml
- if: github.ref == 'refs/heads/main' && github.actor != 'dependabot[bot]'
  uses: peter-evans/create-pull-request@271a8d0
```

No new secret, no other change.

## Why

Every open Dependabot PR fails `generate_report`, and none of them fail because of the dependency they bump. The job pushes the `test-vpat-report` branch via `peter-evans/create-pull-request`, and **Dependabot-triggered runs receive a read-only `GITHUB_TOKEN`**, so the push 403s:

```
remote: Permission to dequelabs/action-vpat-report.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/dequelabs/action-vpat-report/':
       The requested URL returned error: 403
```

The actor decides the outcome, not the diff:

| Run | Actor | `generate_report` |
|---|---|---|
| #31 setup-node 6→7 | `dependabot[bot]` | ❌ 403 |
| #30 checkout 4→7 | `dependabot[bot]` | ❌ 403 |
| #29 npm_and_yarn group | `dependabot[bot]` | ❌ 403 |
| #27 create-pull-request 7.0.8→8.1.1 | `dependabot[bot]` | ❌ 403 |
| `dependabot/…/setup-node-6` (→ #22) | `Bracciata` | ✅ pass |
| `dependabot/npm_and_yarn/…3c67cbb9cd` | `Bracciata` | ✅ pass |
| `main` pushes | human | ✅ pass |

The two green Dependabot *branches* are green only because they were pushed by hand, which flips the actor to a human and restores a writable token. Left alone, this fails on every future Dependabot PR too.

## Why gate rather than authenticate

Publishing the sample VPAT is the only part of this job that needs write access. Getting a writable token into a Dependabot-triggered run means a PAT in the **Dependabot** secret store (Actions secrets are not exposed to those runs) — which needs repo admin, and widens the blast radius: code paths driven by a dependency update would be able to push to this repo, which is precisely what GitHub's read-only default is there to prevent.

Gating costs nothing that matters. The sample VPAT only needs refreshing when `main` changes, and **the `uses: ./` step above still runs on every branch**, so a bump that breaks report generation is still caught — the job exercises the action end-to-end either way.

The actor clause is a second guard: it keeps `main` green if a Dependabot-authored push ever lands there directly (auto-merge), which would hit the same read-only token.

## Side effect worth knowing

Human pushes to non-`main` branches no longer refresh the `test-vpat-report` PR. That refresh was incidental — it fired on *every* branch push, rewriting a shared branch from whichever branch happened to be pushed last. It now tracks `main`, which is the only base it opens against anyway.

## Considered and rejected

- **A `permissions:` block.** Cannot help: a Dependabot-triggered `GITHUB_TOKEN` is capped read-only regardless of what the workflow requests.
- **A PAT in the Dependabot secret store.** Works, and keeps the publish firing on Dependabot PRs too — but needs admin to create, adds a token to rotate, and hands push rights to a dependency-update-triggered code path.

## Verification

`generate_report` passes on this branch with the publish step correctly skipped, and no new `test-vpat-report` commit or PR was produced by the push. After merge, the four Dependabot PRs need `@dependabot rebase` (`recreate` for #27, whose one-line `uses:` bump sits in the hunk this PR touches) to pick the guard up.

## Not included

`action.yml` still declares `runs.using: node20`, which GitHub is deprecating and which warns on every run. Left alone here: it changes the runtime for every consumer of this action, not just this repo's CI, so it deserves its own PR.
